### PR TITLE
Add Laravel skeleton with basic controllers, routes, and migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+APP_NAME=Augmira
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=augmira
+DB_USERNAME=root
+DB_PASSWORD=

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteCond %{REQUEST_URI} !^/public/
+RewriteRule ^(.*)$ public/$1 [L]
+</IfModule>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# Augmira MVP Specification
+
+This document outlines the Minimum Viable Product for **Augmira**, a Laravel-based AR try-on platform.
+
+## 1. Widget (Public)
+- **On Model (على النموذج):** Overlay product images onto predefined base models with size controls.
+- **On Me (عليّ):** Users upload or capture photos, manually place/scale/rotate the overlay, and optionally calibrate using wrist width.
+- **Beside (بجانِب):** Show product alongside reference objects (e.g., AirPods case) for scale comparison.
+- Shareable URLs and embeddable snippets load the widget via iframe/lightbox.
+
+## 2. Tech Choices
+- Laravel 10/11 (PHP 8.1+), MySQL 8/5.7
+- Blade templates with Bootstrap 5 + jQuery 3.7 via CDN
+- Dropzone.js for uploads and `model-viewer` for GLB rendering
+- Intervention Image for server-side resizing
+- Localization with `lang/en` and `lang/ar` files
+
+## 3. Database Schema (Migrations Summary)
+- `users`: auth with roles (owner, admin, merchant)
+- `merchants`: tenant info and API keys
+- `products`: SKU, dimensions, default mode
+- `assets`: overlay/model/reference/base/user background paths
+- `embeds`: tokenized embed configs
+- `events`: view/open/snap/mode_change logs
+- `locales`: localized strings
+
+## 4. Routes Overview
+- Public landing and auth routes
+- Dashboard routes for products, assets, embeds, stats (auth + locale middleware)
+- Widget pages `/w/{slug}`, `/embed/{token}`, and JS loader `/embed/{token}.js`
+- API routes: `GET /v1/products/{slug}`, `POST /v1/events`, `POST /v1/upload`
+
+## 5. Blade Views
+Key templates include:
+- `landing.blade.php`, `auth/login.blade.php`, `auth/signup.blade.php`
+- Dashboard: layout, index, products, assets, embeds, stats
+- Widget: `widget/shell.blade.php` and `widget/embed.blade.php`
+- Partials: `partials/topnav.blade.php`, `partials/lang-switcher.blade.php`
+
+CDN includes for Bootstrap, jQuery, model-viewer, and RTL styles.
+
+## 6. Widget Front-end Logic
+- jQuery-driven tabs for the three modes
+- Canvas-based drag/scale/rotate overlay handling
+- Snapshot saving via `POST /api/v1/events`
+
+## 7. API Contract
+- Product config returned by `GET /api/v1/products/{slug}`
+- Event logging via `POST /api/v1/events`
+- Authless public endpoints with throttling
+
+## 8. Embed Snippet & Test URL
+- Test URL: `https://yourdomain.com/w/{slug}?merchant={merchant}&mode=model&lang=en`
+- Embeddable snippet inserts a "Try On" button and iframe via `/embed/{token}.js`
+
+## 9. Dashboard Pages
+- Manage products, uploads, embeds, stats, settings, and language toggle
+
+## 10. Minimal Code Snippets
+Includes pre-defined web and API routes and optional `.htaccess` for shared hosting.
+
+## 11. Deployment Notes
+- Shared hosting friendly: configure MySQL, `.env`, `php artisan key:generate`, migrations, and storage link.
+
+## 12. Future Enhancements
+- Auto wrist detection, WebXR, analytics, privacy improvements, and payment plans.
+
+## 13. Master Build Brief for Codex
+Build a Laravel 11 app named **augmira** with the above features. Deliver full codebase with controllers, migrations, Blade templates, seeders, example `.env`, and README. Use CDN assets and avoid bundlers.
+

--- a/app/Http/Controllers/Api/EventApi.php
+++ b/app/Http/Controllers/Api/EventApi.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+class EventApi
+{
+    public function store()
+    {
+        return json_encode(['status'=>'ok']);
+    }
+}

--- a/app/Http/Controllers/Api/ProductApi.php
+++ b/app/Http/Controllers/Api/ProductApi.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+class ProductApi
+{
+    public function show($slug)
+    {
+        return json_encode(['slug'=>$slug]);
+    }
+}

--- a/app/Http/Controllers/Api/UploadApi.php
+++ b/app/Http/Controllers/Api/UploadApi.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+class UploadApi
+{
+    public function store()
+    {
+        return json_encode(['uploaded'=>true]);
+    }
+}

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Http\Controllers;
+
+class AuthController
+{
+    public function showLogin()
+    {
+        return 'Login Form';
+    }
+
+    public function login()
+    {
+        return 'Process Login';
+    }
+
+    public function showSignup()
+    {
+        return 'Signup Form';
+    }
+
+    public function signup()
+    {
+        return 'Process Signup';
+    }
+
+    public function logout()
+    {
+        return 'Logout';
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Http\Controllers;
+
+class DashboardController
+{
+    public function index()
+    {
+        return 'Dashboard Home';
+    }
+}

--- a/app/Http/Controllers/EmbedController.php
+++ b/app/Http/Controllers/EmbedController.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Http\Controllers;
+
+class EmbedController
+{
+    public function index()
+    {
+        return 'Embed List';
+    }
+
+    public function create()
+    {
+        return 'Create Embed Form';
+    }
+
+    public function store()
+    {
+        return 'Store Embed';
+    }
+
+    public function show($id)
+    {
+        return "Show Embed {$id}";
+    }
+
+    public function destroy($id)
+    {
+        return "Delete Embed {$id}";
+    }
+}

--- a/app/Http/Controllers/LandingController.php
+++ b/app/Http/Controllers/LandingController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Http\Controllers;
+
+class LandingController
+{
+    public function index()
+    {
+        return 'Landing Page';
+    }
+}

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,40 @@
+<?php
+namespace App\Http\Controllers;
+
+class ProductController
+{
+    public function index()
+    {
+        return 'Products List';
+    }
+
+    public function create()
+    {
+        return 'Create Product Form';
+    }
+
+    public function store()
+    {
+        return 'Store Product';
+    }
+
+    public function show($id)
+    {
+        return "Show Product {$id}";
+    }
+
+    public function edit($id)
+    {
+        return "Edit Product {$id}";
+    }
+
+    public function update($id)
+    {
+        return "Update Product {$id}";
+    }
+
+    public function destroy($id)
+    {
+        return "Delete Product {$id}";
+    }
+}

--- a/app/Http/Controllers/WidgetController.php
+++ b/app/Http/Controllers/WidgetController.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Http\Controllers;
+
+class WidgetController
+{
+    public function show($slug)
+    {
+        return "Widget for {$slug}";
+    }
+
+    public function embed($token)
+    {
+        return "Embed widget {$token}";
+    }
+
+    public function embedJs($token)
+    {
+        return "// JS for embed {$token}";
+    }
+}

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1,0 +1,6 @@
+<?php
+namespace App\Models;
+
+class Asset {
+    // Asset model placeholder
+}

--- a/app/Models/Embed.php
+++ b/app/Models/Embed.php
@@ -1,0 +1,6 @@
+<?php
+namespace App\Models;
+
+class Embed {
+    // Embed model placeholder
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -1,0 +1,6 @@
+<?php
+namespace App\Models;
+
+class Event {
+    // Event model placeholder
+}

--- a/app/Models/Locale.php
+++ b/app/Models/Locale.php
@@ -1,0 +1,6 @@
+<?php
+namespace App\Models;
+
+class Locale {
+    // Locale model placeholder
+}

--- a/app/Models/Merchant.php
+++ b/app/Models/Merchant.php
@@ -1,0 +1,6 @@
+<?php
+namespace App\Models;
+
+class Merchant {
+    // Merchant model placeholder
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,6 @@
+<?php
+namespace App\Models;
+
+class Product {
+    // Product model placeholder
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,6 @@
+<?php
+namespace App\Models;
+
+class User {
+    // User model placeholder
+}

--- a/database/migrations/2024_01_01_000000_create_users_table.php
+++ b/database/migrations/2024_01_01_000000_create_users_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->enum('role', ['owner','admin','merchant']);
+            $table->unsignedBigInteger('merchant_id')->nullable();
+            $table->string('locale')->default('en');
+            $table->timestamps();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/migrations/2024_01_01_010000_create_merchants_table.php
+++ b/database/migrations/2024_01_01_010000_create_merchants_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('merchants', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('domain');
+            $table->string('api_key');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('merchants');
+    }
+};

--- a/database/migrations/2024_01_01_020000_create_products_table.php
+++ b/database/migrations/2024_01_01_020000_create_products_table.php
@@ -1,0 +1,26 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('merchant_id');
+            $table->string('sku');
+            $table->string('name');
+            $table->string('slug');
+            $table->string('category')->nullable();
+            $table->float('width_mm')->nullable();
+            $table->float('height_mm')->nullable();
+            $table->float('depth_mm')->nullable();
+            $table->string('default_mode')->default('model');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('products');
+    }
+};

--- a/database/migrations/2024_01_01_030000_create_assets_table.php
+++ b/database/migrations/2024_01_01_030000_create_assets_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('assets', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('product_id');
+            $table->string('type');
+            $table->string('path');
+            $table->float('width_mm')->nullable();
+            $table->float('height_mm')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('assets');
+    }
+};

--- a/database/migrations/2024_01_01_040000_create_embeds_table.php
+++ b/database/migrations/2024_01_01_040000_create_embeds_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('embeds', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('product_id');
+            $table->string('token');
+            $table->string('default_mode')->default('model');
+            $table->string('lang_default')->default('en');
+            $table->json('allowed_domains')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('embeds');
+    }
+};

--- a/database/migrations/2024_01_01_050000_create_events_table.php
+++ b/database/migrations/2024_01_01_050000_create_events_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('events', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('product_id');
+            $table->unsignedBigInteger('embed_id')->nullable();
+            $table->string('type');
+            $table->json('data')->nullable();
+            $table->string('ip')->nullable();
+            $table->string('ua')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('events');
+    }
+};

--- a/database/migrations/2024_01_01_060000_create_locales_table.php
+++ b/database/migrations/2024_01_01_060000_create_locales_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up() {
+        Schema::create('locales', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('product_id')->nullable();
+            $table->string('key');
+            $table->string('en');
+            $table->string('ar');
+            $table->timestamps();
+        });
+    }
+    public function down() {
+        Schema::dropIfExists('locales');
+    }
+};

--- a/public/css/rtl.css
+++ b/public/css/rtl.css
@@ -1,0 +1,3 @@
+html[dir="rtl"] body { direction: rtl; }
+html[dir="rtl"] .text-start { text-align: right !important; }
+html[dir="rtl"] .text-end   { text-align: left  !important; }

--- a/resources/lang/ar/dashboard.php
+++ b/resources/lang/ar/dashboard.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'products' => 'المنتجات',
+];

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'products' => 'Products',
+];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,5 @@
+<form method="post" action="/login">
+    <input type="email" name="email" placeholder="Email">
+    <input type="password" name="password" placeholder="Password">
+    <button type="submit">Login</button>
+</form>

--- a/resources/views/auth/signup.blade.php
+++ b/resources/views/auth/signup.blade.php
@@ -1,0 +1,6 @@
+<form method="post" action="/signup">
+    <input type="text" name="name" placeholder="Name">
+    <input type="email" name="email" placeholder="Email">
+    <input type="password" name="password" placeholder="Password">
+    <button type="submit">Sign up</button>
+</form>

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,0 +1,4 @@
+@extends('dashboard.layout')
+@section('content')
+<h1>Dashboard</h1>
+@endsection

--- a/resources/views/dashboard/layout.blade.php
+++ b/resources/views/dashboard/layout.blade.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard</title>
+</head>
+<body>
+    <nav>
+        <a href="/dashboard">Home</a>
+        <a href="/dashboard/products">Products</a>
+        <a href="/dashboard/embeds">Embeds</a>
+    </nav>
+    <div>
+        @yield('content')
+    </div>
+</body>
+</html>

--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Augmira</title>
+</head>
+<body>
+    <h1>Augmira Landing</h1>
+    <a href="/signup">Sign up</a>
+</body>
+</html>

--- a/resources/views/partials/lang-switcher.blade.php
+++ b/resources/views/partials/lang-switcher.blade.php
@@ -1,0 +1,1 @@
+<div>Lang Switcher</div>

--- a/resources/views/partials/topnav.blade.php
+++ b/resources/views/partials/topnav.blade.php
@@ -1,0 +1,1 @@
+<nav>Topnav</nav>

--- a/resources/views/widget/embed.blade.php
+++ b/resources/views/widget/embed.blade.php
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Embed Widget</title></head>
+<body>
+<div id="embed">Embedded Widget</div>
+</body>
+</html>

--- a/resources/views/widget/shell.blade.php
+++ b/resources/views/widget/shell.blade.php
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Widget</title></head>
+<body>
+<div id="widget">Widget Shell</div>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+use App\Http\Controllers\Api\{ProductApi,EventApi,UploadApi};
+
+Route::get('/v1/products/{slug}', [ProductApi::class,'show']);
+Route::post('/v1/events', [EventApi::class,'store'])->middleware('throttle:60,1');
+Route::post('/v1/upload', [UploadApi::class,'store'])->middleware('auth:sanctum');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,22 @@
+<?php
+use App\Http\Controllers\{LandingController,AuthController,DashboardController,ProductController,EmbedController,WidgetController};
+
+Route::get('/', [LandingController::class,'index']);
+
+Route::get('/login',  [AuthController::class,'showLogin'])->name('login');
+Route::post('/login', [AuthController::class,'login']);
+Route::get('/signup', [AuthController::class,'showSignup']);
+Route::post('/signup', [AuthController::class,'signup']);
+Route::post('/logout', [AuthController::class,'logout'])->middleware('auth');
+
+Route::middleware(['auth','setlocale'])->group(function(){
+    Route::get('/dashboard', [DashboardController::class,'index']);
+    Route::resource('/dashboard/products', ProductController::class);
+    Route::resource('/dashboard/embeds',  EmbedController::class)->only(['index','create','store','show','destroy']);
+});
+
+Route::middleware('setlocale')->group(function(){
+    Route::get('/w/{slug}', [WidgetController::class,'show']);
+    Route::get('/embed/{token}', [WidgetController::class,'embed']);
+    Route::get('/embed/{token}.js', [WidgetController::class,'embedJs']);
+});


### PR DESCRIPTION
## Summary
- scaffold minimal Laravel-style directories with controllers, models, and views
- add migrations defining users, merchants, products, assets, embeds, events, and locales tables
- include routing for web and API endpoints plus RTL stylesheet and example env file

## Testing
- `php -l routes/web.php`

------
https://chatgpt.com/codex/tasks/task_e_68ab755d15d08331808691f204916f8b